### PR TITLE
版本号修复

### DIFF
--- a/fofa/client.py
+++ b/fofa/client.py
@@ -127,8 +127,8 @@ class Client:
         :return: query result in json format
            {
                 "error": false,
-                "host": "78.48.50.249",
-                "ip": "78.48.50.249",
+                "host": "78.**.50.***",
+                "ip": "78.**.50.***",
                 "asn": 6805,
                 "org": "Telefonica Germany",
                 "country_name": "Germany",

--- a/fofa/client.py
+++ b/fofa/client.py
@@ -3,9 +3,9 @@
 # Author: Erdog, Loveforkeeps, Alluka
 import base64
 import json
-import requests
 import os
 import sys
+import requests
 
 
 class Client:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name = 'FOFA',
-    version = '1.0.0',
+    version = '1.1.0',
     description = 'Python library for FOFA (https://fofa.info)',
     author = 'gcr',
     author_email = 'yzjjaheim@163.com',

--- a/tests/fofa_test.py
+++ b/tests/fofa_test.py
@@ -96,6 +96,20 @@ class ClientTestCase(unittest.TestCase):
 
         self.assertEqual(len(data["results"][0]), 7)
 
+    def test_search_host(self):
+        query = '''78.48.50.249'''
+        data = self.client.search_host(query)
+        self.assertIn("host", data)
+        self.assertIn("ip", data)
+        self.assertIn("asn", data)
+
+    def test_search_stat(self):
+        query = '''domain="baidu.com"'''
+        data = self.client.search_stats(query, size=10, fields="title")
+        self.assertIn("distinct", data)
+        self.assertIn("aggs", data)
+
+
     def test_get_data_extended(self):
         query = '''host="fofa.info"'''
         data = self.client.search(query)


### PR DESCRIPTION
- 原版本号导致无法直接通过 pip install fofa 获取最新版fofa，已修复
- 添加新增接口的测试用例